### PR TITLE
Python3 compatibility

### DIFF
--- a/vdist/builder.py
+++ b/vdist/builder.py
@@ -199,7 +199,8 @@ class Builder(object):
     def _create_build_basedir(self):
         os.mkdir(self.build_basedir)
 
-    def _write_build_script(self, path, script):
+    @staticmethod
+    def _write_build_script(path, script):
         with open(path, 'w+') as f:
             f.write(script)
         os.chmod(path, 0o777)

--- a/vdist/buildmachine.py
+++ b/vdist/buildmachine.py
@@ -61,12 +61,7 @@ class BuildMachine(object):
     def launch(self, build_dir, extra_binds=None):
         binds = {build_dir: defaults.SHARED_DIR}
         if extra_binds:
-            if defaults.PYTHON3_INTERPRETER:
-                binds = list(itertools.chain(binds.items(),
-                                             extra_binds.items()))
-            else:
-                binds = binds.items() + extra_binds.items()
-
+            binds = list(itertools.chain(binds.items(), extra_binds.items()))
         path_to_command = os.path.join(
             defaults.SHARED_DIR,
             defaults.SCRATCH_DIR,

--- a/vdist/buildmachine.py
+++ b/vdist/buildmachine.py
@@ -32,14 +32,14 @@ class BuildMachine(object):
         )
         first_line = None
         for line in iter(p.stdout.readline, b''):
-            line = line.strip()
+            line = str(line.decode("UTF-8")).strip()
             if not first_line:
                 first_line = line
 
             self.logger.info(line)
 
         for line in iter(p.stderr.readline, b''):
-            line = line.strip()
+            line = str(line.decode("UTF-8")).strip()
             if not first_line:
                 first_line = line
 

--- a/vdist/buildmachine.py
+++ b/vdist/buildmachine.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 import os
 import subprocess
@@ -50,14 +51,22 @@ class BuildMachine(object):
 
         return first_line
 
-    def _binds_to_shell_volumes(self, binds):
-        vol_list = ['-v %s:%s' % (k, v) for k, v in binds.iteritems()]
+    @staticmethod
+    def _binds_to_shell_volumes(binds):
+        if defaults.PYTHON3_INTERPRETER:
+            vol_list = ['-v %s:%s' % (k, v) for k, v in binds.items()]
+        else:
+            vol_list = ['-v %s:%s' % (k, v) for k, v in binds.iteritems()]
         return ' '.join(vol_list)
 
     def launch(self, build_dir, extra_binds=None):
         binds = {build_dir: defaults.SHARED_DIR}
         if extra_binds:
-            binds = binds.items() + extra_binds.items()
+            if defaults.PYTHON3_INTERPRETER:
+                binds = list(itertools.chain(binds.items(),
+                                             extra_binds.items()))
+            else:
+                binds = binds.items() + extra_binds.items()
 
         path_to_command = os.path.join(
             defaults.SHARED_DIR,

--- a/vdist/buildmachine.py
+++ b/vdist/buildmachine.py
@@ -30,25 +30,24 @@ class BuildMachine(object):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         )
-        first_line = None
-        for line in iter(p.stdout.readline, b''):
-            line = str(line.decode("UTF-8")).strip()
-            if not first_line:
-                first_line = line
 
-            self.logger.info(line)
-
-        for line in iter(p.stderr.readline, b''):
-            line = str(line.decode("UTF-8")).strip()
-            if not first_line:
-                first_line = line
-
-            self.logger.info(line)
+        media = [p.stdout, p.stderr]
+        first_line = self._read_from_media(media)
 
         p.stdout.close()
         p.stderr.close()
         p.wait()
 
+        return first_line
+
+    def _read_from_media(self, media):
+        first_line = None
+        for input_to_read in media:
+            for line in iter(input_to_read.readline, b''):
+                line = str(line.decode("UTF-8")).strip()
+                if not first_line:
+                    first_line = line
+                self.logger.info(line)
         return first_line
 
     @staticmethod

--- a/vdist/defaults.py
+++ b/vdist/defaults.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 PYTHON_BASEDIR = '/opt/vdist-python'
 PYTHON_VERSION = '2.7.9'
@@ -10,3 +11,5 @@ SCRATCH_BUILDSCRIPT_NAME = 'buildscript.sh'
 SCRATCH_DIR = 'scratch'
 SHARED_DIR = '/work'
 PACKAGE_BUILD_ROOT = '/opt'
+
+PYTHON3_INTERPRETER = True if sys.version_info[0] == 3 else False


### PR DESCRIPTION
Modifications to make vdist runnable from both Python 2.x and Python 3.x.

It passes unit tests and integration tests.
