### PR TITLE
Launcher

### DIFF
--- a/docs/howtouse.md
+++ b/docs/howtouse.md
@@ -48,6 +48,11 @@ profile = ubuntu-trusty
 profile = centos7
 ```
 
+Running vdist with last configuration file will place generated packages at path
+you set in *output_folder* variable. If you don't use absolute path but a
+relative one, then reference folder is the one where you are when vdist command
+is called. **Always set *output_folder* variable**.
+
 As you can see, there are three main **sections** in previous configuration: DEFAULT,
 Ubuntu-package, Centos7-package. You can name each section as you want but
 DEFAULT that should always exists in your configurations because, as its name

--- a/integration-tests/test_builder.py
+++ b/integration-tests/test_builder.py
@@ -1,3 +1,8 @@
+# TODO: Fix centos6 profile. All centos6 fail because a problem with
+# when installing FPM.
+# Full log of a failed tests with error about the end in:
+#   https://gist.github.com/dante-signal31/60b2a1b8952736e7c11989ca45895398#file-test_builder-py
+
 import os
 import re
 import subprocess

--- a/integration-tests/test_builder.py
+++ b/integration-tests/test_builder.py
@@ -1,8 +1,3 @@
-# TODO: Fix centos6 profile. All centos6 fail because a problem
-# when installing FPM.
-# Full log of a failed tests with error about the end in:
-#   https://gist.github.com/dante-signal31/60b2a1b8952736e7c11989ca45895398#file-test_builder-py
-
 import os
 import re
 import subprocess

--- a/integration-tests/test_builder.py
+++ b/integration-tests/test_builder.py
@@ -43,6 +43,8 @@ def _call_builder(builder_parameters):
 def _generate_rpm(builder_parameters, centos_version):
     _call_builder(builder_parameters)
     homedir = os.path.expanduser('~')
+    # TODO: Redundancy detected. Should refactor this and rerun integration
+    # tests.
     filename_prefix = "-".join([builder_parameters["app"],
                                 builder_parameters["version"]])
     rpm_filename_prefix = "-".join([builder_parameters["app"],

--- a/integration-tests/test_builder.py
+++ b/integration-tests/test_builder.py
@@ -1,4 +1,4 @@
-# TODO: Fix centos6 profile. All centos6 fail because a problem with
+# TODO: Fix centos6 profile. All centos6 fail because a problem
 # when installing FPM.
 # Full log of a failed tests with error about the end in:
 #   https://gist.github.com/dante-signal31/60b2a1b8952736e7c11989ca45895398#file-test_builder-py
@@ -48,18 +48,14 @@ def _call_builder(builder_parameters):
 def _generate_rpm(builder_parameters, centos_version):
     _call_builder(builder_parameters)
     homedir = os.path.expanduser('~')
-    # TODO: Redundancy detected. Should refactor this and rerun integration
-    # tests.
     filename_prefix = "-".join([builder_parameters["app"],
                                 builder_parameters["version"]])
-    rpm_filename_prefix = "-".join([builder_parameters["app"],
-                                    builder_parameters["version"]])
     target_file = os.path.join(
         homedir,
         '.vdist',
         'dist',
         "".join([filename_prefix, "-{0}".format(centos_version)]),
-        "".join([rpm_filename_prefix, '-1.x86_64.rpm']),
+        "".join([filename_prefix, '-1.x86_64.rpm']),
     )
     assert os.path.isfile(target_file)
     assert os.path.getsize(target_file) > 0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     url='https://github.com/objectified/vdist',
     packages=find_packages(),
     install_requires=['jinja2==2.7.3'],
-    entry_points={'console_scripts': ['vdist=vdist.vdist:main', ], },
+    entry_points={'console_scripts': ['vdist=vdist.vdist_launcher:main', ], },
     package_data={'': ['internal_profiles.json', '*.sh']},
     tests_require=['pytest'],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='vdist',
-    version='0.5',
+    version='1.0',
     description='Create OS packages from Python '
                 'projects using Docker containers',
     long_description='Create OS packages from Python '
@@ -13,6 +13,7 @@ setup(
     url='https://github.com/objectified/vdist',
     packages=find_packages(),
     install_requires=['jinja2==2.7.3'],
+    entry_points={'console_scripts': ['vdist=vdist.vdist:main', ], },
     package_data={'': ['internal_profiles.json', '*.sh']},
     tests_require=['pytest'],
     classifiers=[
@@ -25,6 +26,9 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
     ],
+    zip_safe=False,
     keywords='python docker deployment packaging',
 )

--- a/tests/test_console_launcher.py
+++ b/tests/test_console_launcher.py
@@ -1,7 +1,11 @@
 import contextlib
 import copy
 import os.path
+import sys
 import tempfile
+
+if sys.version_info[0] != 3:
+    from testing_tools import TemporaryDirectory as OwnTemporaryDirectory
 
 # TODO: Something has to be wrong with my way os doing imports. If pytest is run
 # with python 3 all goes fine, but if I use python 2 all tests folder's tests
@@ -12,15 +16,76 @@ import vdist.configuration as configuration
 import vdist.source as source
 import vdist.vdist as vdist
 
-DUMMY_CONFIGURATION_TEXT = """[DEFAULT]
+# Python 2.x ConfigParser lacks of extended interpolation support and its
+# tag format changes, so you should alter your config text depending whether
+# you are building with Python 3 or not.
+if sys.version_info[0] == 3:
+#     DUMMY_CONFIGURATION_TEXT = """[DEFAULT]
+# app = geolocate
+# version = 1.3.0
+# source_git = https://github.com/dante-signal31/${app}, master
+# fpm_args = --maintainer dante.signal31@gmail.com -a native --url
+#     https://github.com/dante-signal31/${app} --description
+#     "This program accepts any text and searchs inside every IP
+#     address. With each of those IP addresses,
+#     ${app} queries
+#     Maxmind GeoIP database to look for the city and
+#     country where
+#     IP address or URL is located. Geolocate is designed to be
+#     used in console with pipes and redirections along with
+#     applications like traceroute, nslookup, etc."
+#     --license BSD-3 --category net
+# requirements_path = /REQUIREMENTS.txt
+# runtime_deps = libssl1.0.0, dummy1.0.0
+# compile_python = True
+# python_version = 3.4.4
+# output_folder = ./vdist
+#
+# [Ubuntu-package]
+# profile = ubuntu-trusty
+#
+# [Centos7-package]
+# profile = centos7
+# """
+
+## TODO: Check if I can use the same format for fpm_args in Pyhton3 and Python 2.
+    DUMMY_CONFIGURATION_TEXT = """[DEFAULT]
+    app = geolocate
+    version = 1.3.0
+    source_git = https://github.com/dante-signal31/${app}, master
+    fpm_args = --maintainer dante.signal31@gmail.com -a native --url
+        https://github.com/dante-signal31/${app} --description
+        "This program accepts any text and searchs inside every IP
+        address. With each of those IP addresses,
+        ${app} queries
+        Maxmind GeoIP database to look for the city and
+        country where
+        IP address or URL is located. Geolocate is designed to be
+        used in console with pipes and redirections along with
+        applications like traceroute, nslookup, etc."
+        --license BSD-3 --category net
+    requirements_path = /REQUIREMENTS.txt
+    runtime_deps = libssl1.0.0, dummy1.0.0
+    compile_python = True
+    python_version = 3.4.4
+    output_folder = ./vdist
+
+    [Ubuntu-package]
+    profile = ubuntu-trusty
+
+    [Centos7-package]
+    profile = centos7
+    """
+else:
+    DUMMY_CONFIGURATION_TEXT = """[DEFAULT]
 app = geolocate
 version = 1.3.0
-source_git = https://github.com/dante-signal31/${app}, master
+source_git = https://github.com/dante-signal31/%(app)s, master
 fpm_args = --maintainer dante.signal31@gmail.com -a native --url
-    https://github.com/dante-signal31/${app} --description
+    https://github.com/dante-signal31/%(app)s --description
     "This program accepts any text and searchs inside every IP
     address. With each of those IP addresses,
-    ${app} queries
+    %(app)s queries
     Maxmind GeoIP database to look for the city and
     country where
     IP address or URL is located. Geolocate is designed to be
@@ -36,11 +101,8 @@ output_folder = ./vdist
 [Ubuntu-package]
 profile = ubuntu-trusty
 
-[Centos6-package]
-profile = centos6
-
 [Centos7-package]
-profile = centos
+profile = centos7
 """
 
 DUMMY_OUTPUT_FOLDER = "/tmp/vdist"
@@ -48,7 +110,7 @@ DUMMY_OUTPUT_FOLDER = "/tmp/vdist"
 UBUNTU_ARGPARSED_ARGUMENTS = {
         "app": 'geolocate',
         "version": '1.3.0',
-        "source": "https://github.com/dante-signal31/geolocate, master",
+        "source_git": "https://github.com/dante-signal31/geolocate, master",
         "profile": 'ubuntu-trusty',
         "compile_python": "True",
         "python_version": '3.4.4',
@@ -64,7 +126,7 @@ UBUNTU_ARGPARSED_ARGUMENTS = {
                     'applications like traceroute, nslookup, etc."'
                     ' --license BSD-3 --category net',
         "requirements_path": '/REQUIREMENTS.txt',
-        "runtime_deps": "libssl1.0.0, dummy1.0.0",
+        "runtime_deps": ["libssl1.0.0", "dummy1.0.0"],
         "output_folder": DUMMY_OUTPUT_FOLDER
 }
 
@@ -99,11 +161,11 @@ DUMMY_CONFIGURATION_ARGUMENTS = copy.deepcopy(CORRECT_UBUNTU_PARAMETERS)
 DUMMY_CONFIGURATION_ARGUMENTS["output_folder"] = DUMMY_OUTPUT_FOLDER
 DUMMY_CONFIGURATION = configuration.Configuration(UBUNTU_ARGPARSED_ARGUMENTS)
 CORRECT_OUTPUT_FOLDER = "./vdist"
-DUMMY_CONFIGURATION_FILE_ARGUMENTS = ["vdist", "batch", "config.cfg"]
-DUMMY_MANUAL_ARGUMENTS = ["vdist", "manual",
+DUMMY_CONFIGURATION_FILE_ARGUMENTS = ["batch", "config.cfg"]
+DUMMY_MANUAL_ARGUMENTS = ["manual",
                           "--app", "geolocate",
                           "--version", "1.3.0",
-                          "--source-git", "https://github.com/dante-signal31/geolocate,master",
+                          "--source_git", "https://github.com/dante-signal31/geolocate, master",
                           "--profile", "ubuntu-trusty",
                           "--compile_python",
                           "--python_version", "3.4.4",
@@ -119,7 +181,7 @@ DUMMY_MANUAL_ARGUMENTS = ["vdist", "manual",
                                         'applications like traceroute, nslookup, etc."'
                                         ' --license BSD-3 --category net',
                           "--requirements_path", "/REQUIREMENTS.txt",
-                          "--runtime_deps", "libssl1.0.0, dummy1.0.0",
+                          "--runtime_deps", "libssl1.0.0", "dummy1.0.0",
                           "--output_folder", DUMMY_OUTPUT_FOLDER]
 
 
@@ -140,38 +202,85 @@ def test_configuration_file_read():
         assert "Centos7-package" in configurations
 
 
-def test_parse_arguments_configuration_file():
-    parsed_arguments = console_parser.parse_arguments(DUMMY_CONFIGURATION_FILE_ARGUMENTS)
-    assert parsed_arguments["configuration_file"] == "config.cfg"
+def test_parse_arguments():
+    # Batch mode
+    parsed_arguments = console_parser.parse_arguments(["batch", "/etc/passwd"])
+    assert parsed_arguments["configuration_file"] == "/etc/passwd"
+    # Manual mode
+    parsed_arguments = console_parser.parse_arguments(DUMMY_MANUAL_ARGUMENTS)
+    assert parsed_arguments == UBUNTU_ARGPARSED_ARGUMENTS
 
 
 def test_move_package_to_output_folder():
-    with tempfile.TemporaryDirectory() as tempdir:
+    temporary_directory = _get_temporary_directory_context_manager()
+    with temporary_directory() as tempdir:
+        package_folder = os.path.join(tempdir, DUMMY_PACKAGE_NAME)
+        os.mkdir(package_folder)
         with tempfile.NamedTemporaryFile(prefix=DUMMY_PACKAGE_NAME,
                                          suffix=DUMMY_PACKAGE_EXTENSION,
-                                         dir=tempdir) as dummy_package:
+                                         dir=package_folder) as dummy_package:
             dummy_source_folder, dummy_package_name = os.path.split(dummy_package.name)
             builder._move_package_to_output_folder(DUMMY_CONFIGURATION,
-                                                   source_folder=dummy_source_folder)
+                                                   source_folder=tempdir)
             correct_package = os.path.join(DUMMY_OUTPUT_FOLDER,
                                            dummy_package_name)
             assert os.path.isfile(correct_package)
 
 
+def _get_temporary_directory_context_manager():
+    if sys.version_info[0] == 3:
+        temporary_directory = tempfile.TemporaryDirectory
+    else:
+        temporary_directory = OwnTemporaryDirectory
+    return temporary_directory
+
+
 def test_build_package_batch():
     with _create_dummy_configuration_file(DUMMY_CONFIGURATION_TEXT) as config_file:
-        configurations = configuration.read(config_file)
-        builder.build_package(configurations[0])
-        correct_output_package = os.path.join(configurations[0].output_folder,
-                                              ".".join(DUMMY_PACKAGE_NAME, "deb"))
-        assert os.path.isfile(correct_output_package)
+        configurations = configuration.read(config_file.name)
+        _generate_packages(configurations)
 
 
 def test_build_package_manual():
     console_arguments = console_parser.parse_arguments(DUMMY_MANUAL_ARGUMENTS)
     configurations = vdist._get_build_configurations(console_arguments)
-    for _configuration in configurations:
-        builder.build_package(configurations[_configuration])
-    correct_output_package = os.path.join(configurations[0].output_folder,
-                                          ".".join(DUMMY_PACKAGE_NAME, "deb"))
-    assert os.path.isfile(correct_output_package)
+    _generate_packages(configurations)
+
+
+def _generate_packages(configurations):
+    for _configuration in configurations.values():
+        package_configuration = configuration.Configuration(_configuration)
+        builder.build_package(package_configuration)
+        correct_output_package = os.path.join(
+            package_configuration.output_folder,
+            _get_correct_package_name(package_configuration))
+        assert os.path.isfile(correct_output_package)
+
+
+def _get_correct_package_name(_configuration):
+    profile = _configuration.builder_parameters["profile"]
+    package_name = None
+    if profile == "ubuntu-trusty":
+        package_name = "_".join([_configuration.builder_parameters["app"],
+                                 _configuration.builder_parameters["version"],
+                                 'amd64.deb'])
+    elif profile == "centos6" or profile == "centos7":
+        package_name = "-".join([_configuration.builder_parameters["app"],
+                                 _configuration.builder_parameters["version"],
+                                '1.x86_64.rpm'])
+    else:
+        raise UnknownProfile(profile)
+    return package_name
+
+
+class Error(Exception):
+    pass
+
+
+class UnknownProfile(Error):
+
+    def __init__(self, tried_profile):
+        super().__init__()
+        self.messsage = "Tried profile: {0}".format(tried_profile)
+
+

--- a/tests/test_console_launcher.py
+++ b/tests/test_console_launcher.py
@@ -79,52 +79,53 @@ profile = centos7
 DUMMY_OUTPUT_FOLDER = "/tmp/vdist"
 
 UBUNTU_ARGPARSED_ARGUMENTS = {
-        "app": 'geolocate',
-        "version": '1.3.0',
-        "source_git": "https://github.com/dante-signal31/geolocate, master",
-        "profile": 'ubuntu-trusty',
-        "compile_python": "True",
-        "python_version": '3.4.4',
-        "fpm_args": '--maintainer dante.signal31@gmail.com -a native --url '
-                    'https://github.com/dante-signal31/geolocate --description '
-                    '"This program accepts any text and searchs inside every IP'
-                    ' address. With each of those IP addresses, '
-                    'geolocate queries '
-                    'Maxmind GeoIP database to look for the city and '
-                    'country where'
-                    ' IP address or URL is located. Geolocate is designed to be'
-                    ' used in console with pipes and redirections along with '
-                    'applications like traceroute, nslookup, etc."'
-                    ' --license BSD-3 --category net',
-        "requirements_path": '/REQUIREMENTS.txt',
-        "runtime_deps": ["libssl1.0.0", "dummy1.0.0"],
-        "output_folder": DUMMY_OUTPUT_FOLDER
+    "mode": "manual",
+    "app": 'geolocate',
+    "version": '1.3.0',
+    "source_git": "https://github.com/dante-signal31/geolocate, master",
+    "profile": 'ubuntu-trusty',
+    "compile_python": "True",
+    "python_version": '3.4.4',
+    "fpm_args": '--maintainer dante.signal31@gmail.com -a native --url '
+                'https://github.com/dante-signal31/geolocate --description '
+                '"This program accepts any text and searchs inside every IP'
+                ' address. With each of those IP addresses, '
+                'geolocate queries '
+                'Maxmind GeoIP database to look for the city and '
+                'country where'
+                ' IP address or URL is located. Geolocate is designed to be'
+                ' used in console with pipes and redirections along with '
+                'applications like traceroute, nslookup, etc."'
+                ' --license BSD-3 --category net',
+    "requirements_path": '/REQUIREMENTS.txt',
+    "runtime_deps": ["libssl1.0.0", "dummy1.0.0"],
+    "output_folder": DUMMY_OUTPUT_FOLDER
 }
 
 CORRECT_UBUNTU_PARAMETERS = {
-        "app": 'geolocate',
-        "version": '1.3.0',
-        "source": source.git(
-            uri='https://github.com/dante-signal31/geolocate',
-            branch='master'
-        ),
-        "profile": 'ubuntu-trusty',
-        "compile_python": True,
-        "python_version": '3.4.4',
-        "fpm_args": '--maintainer dante.signal31@gmail.com -a native --url '
-                    'https://github.com/dante-signal31/geolocate --description '
-                    '"This program accepts any text and searchs inside every IP'
-                    ' address. With each of those IP addresses, '
-                    'geolocate queries '
-                    'Maxmind GeoIP database to look for the city and '
-                    'country where'
-                    ' IP address or URL is located. Geolocate is designed to be'
-                    ' used in console with pipes and redirections along with '
-                    'applications like traceroute, nslookup, etc."'
-                    ' --license BSD-3 --category net',
-        "requirements_path": '/REQUIREMENTS.txt',
-        "runtime_deps": ["libssl1.0.0", "dummy1.0.0"]
-    }
+    "app": 'geolocate',
+    "version": '1.3.0',
+    "source": source.git(
+        uri='https://github.com/dante-signal31/geolocate',
+        branch='master'
+    ),
+    "profile": 'ubuntu-trusty',
+    "compile_python": True,
+    "python_version": '3.4.4',
+    "fpm_args": '--maintainer dante.signal31@gmail.com -a native --url '
+                'https://github.com/dante-signal31/geolocate --description '
+                '"This program accepts any text and searchs inside every IP'
+                ' address. With each of those IP addresses, '
+                'geolocate queries '
+                'Maxmind GeoIP database to look for the city and '
+                'country where'
+                ' IP address or URL is located. Geolocate is designed to be'
+                ' used in console with pipes and redirections along with '
+                'applications like traceroute, nslookup, etc."'
+                ' --license BSD-3 --category net',
+    "requirements_path": '/REQUIREMENTS.txt',
+    "runtime_deps": ["libssl1.0.0", "dummy1.0.0"]
+}
 
 DUMMY_PACKAGE_NAME = "geolocate-1.3.0-ubuntu-trusty"
 DUMMY_PACKAGE_EXTENSION = ".deb"
@@ -167,7 +168,7 @@ def _create_dummy_configuration_file(configuration_text):
 def test_configuration_file_read():
     with _create_dummy_configuration_file(DUMMY_CONFIGURATION_TEXT) as config_file:
         configurations = configuration.read(config_file.name)
-        ubuntu_configuration = configuration.Configuration(configurations["Ubuntu-package"])
+        ubuntu_configuration = configurations["Ubuntu-package"]
         assert ubuntu_configuration.builder_parameters == CORRECT_UBUNTU_PARAMETERS
         assert ubuntu_configuration.output_folder == CORRECT_OUTPUT_FOLDER
         assert "Centos7-package" in configurations
@@ -219,8 +220,7 @@ def test_build_package_manual():
 
 
 def _generate_packages(configurations):
-    for _configuration in configurations.values():
-        package_configuration = configuration.Configuration(_configuration)
+    for package_configuration in configurations.values():
         builder.build_package(package_configuration)
         correct_output_package = os.path.join(
             package_configuration.output_folder,

--- a/tests/test_console_launcher.py
+++ b/tests/test_console_launcher.py
@@ -4,51 +4,19 @@ import os.path
 import sys
 import tempfile
 
-if sys.version_info[0] != 3:
-    from testing_tools import TemporaryDirectory as OwnTemporaryDirectory
-
-# TODO: Something has to be wrong with my way os doing imports. If pytest is run
-# with python 3 all goes fine, but if I use python 2 all tests folder's tests
-# fail because ImportErrors (except test_sources.py).
 import vdist.builder as builder
 import vdist.console_parser as console_parser
 import vdist.configuration as configuration
 import vdist.source as source
 import vdist.vdist as vdist
 
+if sys.version_info[0] != 3:
+    from testing_tools import TemporaryDirectory as OwnTemporaryDirectory
+
 # Python 2.x ConfigParser lacks of extended interpolation support and its
 # tag format changes, so you should alter your config text depending whether
 # you are building with Python 3 or not.
 if sys.version_info[0] == 3:
-#     DUMMY_CONFIGURATION_TEXT = """[DEFAULT]
-# app = geolocate
-# version = 1.3.0
-# source_git = https://github.com/dante-signal31/${app}, master
-# fpm_args = --maintainer dante.signal31@gmail.com -a native --url
-#     https://github.com/dante-signal31/${app} --description
-#     "This program accepts any text and searchs inside every IP
-#     address. With each of those IP addresses,
-#     ${app} queries
-#     Maxmind GeoIP database to look for the city and
-#     country where
-#     IP address or URL is located. Geolocate is designed to be
-#     used in console with pipes and redirections along with
-#     applications like traceroute, nslookup, etc."
-#     --license BSD-3 --category net
-# requirements_path = /REQUIREMENTS.txt
-# runtime_deps = libssl1.0.0, dummy1.0.0
-# compile_python = True
-# python_version = 3.4.4
-# output_folder = ./vdist
-#
-# [Ubuntu-package]
-# profile = ubuntu-trusty
-#
-# [Centos7-package]
-# profile = centos7
-# """
-
-## TODO: Check if I can use the same format for fpm_args in Pyhton3 and Python 2.
     DUMMY_CONFIGURATION_TEXT = """[DEFAULT]
     app = geolocate
     version = 1.3.0
@@ -77,6 +45,9 @@ if sys.version_info[0] == 3:
     profile = centos7
     """
 else:
+    # Whereas Python 3's one, Python 2's configparser does not remove tabs
+    # beginning a line, so don't add a tab to this tab to fix indentation or
+    # tests will probably fail miserably.
     DUMMY_CONFIGURATION_TEXT = """[DEFAULT]
 app = geolocate
 version = 1.3.0

--- a/tests/test_console_launcher.py
+++ b/tests/test_console_launcher.py
@@ -1,0 +1,112 @@
+import contextlib
+import os.path
+import tempfile
+
+# TODO: Something has to be wrong with my way os doing imports. If pytest is run
+# with python 3 all goes fine, but if I use python 2 all tests folder's tests
+# fail because ImportErrors (except test_sources.py).
+import vdist.builder as builder
+import vdist.console_parser as console_parser
+import vdist.configuration as configuration
+import vdist.source as source
+
+
+DUMMY_CONFIGURATION_TEXT = """[DEFAULT]
+app = geolocate
+version = 1.3.0
+source = https://github.com/dante-signal31/${app} , master
+fpm_args = --maintainer dante.signal31@gmail.com -a native --url
+    https://github.com/dante-signal31/${app} --description
+    "This program accepts any text and searchs inside every IP
+    address. With each of those IP addresses,
+    ${app} queries
+    Maxmind GeoIP database to look for the city and
+    country where
+    IP address or URL is located. Geolocate is designed to be
+    used in console with pipes and redirections along with
+    applications like traceroute, nslookup, etc."
+    --license BSD-3 --category net
+requirements_path = /REQUIREMENTS.txt
+runtime_deps = libssl1.0.0 , dummy1.0.0
+compile_python = True
+python_version = 3.4.4
+output_folder = ./vdist
+
+[Ubuntu-package]
+profile = ubuntu-trusty
+
+[Centos6-package]
+profile = centos6
+
+[Centos7-package]
+profile = centos
+"""
+
+CORRECT_UBUNTU_PARAMETERS = {
+        "app": 'geolocate',
+        "version": '1.3.0',
+        "source": source.git(
+            uri='https://github.com/dante-signal31/geolocate',
+            branch='master'
+        ),
+        "profile": 'ubuntu-trusty',
+        "compile_python": True,
+        "python_version": '3.4.4',
+        "fpm_args": '--maintainer dante.signal31@gmail.com -a native --url '
+                    'https://github.com/dante-signal31/geolocate --description '
+                    '"This program accepts any text and searchs inside every IP'
+                    ' address. With each of those IP addresses, '
+                    'geolocate queries '
+                    'Maxmind GeoIP database to look for the city and '
+                    'country where'
+                    ' IP address or URL is located. Geolocate is designed to be'
+                    ' used in console with pipes and redirections along with '
+                    'applications like traceroute, nslookup, etc.'
+                    ' " --license BSD-3 --category net',
+        "requirements_path": '/REQUIREMENTS.txt',
+        "runtime_deps": ["libssl1.0.0", "dummy1.0.0"]
+    }
+
+DUMMY_PACKAGE_NAME = "geolocate-1.3.0-ubuntu-trusty"
+DUMMY_OUTPUT_FOLDER = "/tmp"
+DUMMY_CONFIGURATION_ARGUMENTS = CORRECT_UBUNTU_PARAMETERS
+DUMMY_CONFIGURATION_ARGUMENTS["output_folder"] = DUMMY_OUTPUT_FOLDER
+DUMMY_CONFIGURATION = configuration.Configuration(DUMMY_CONFIGURATION_ARGUMENTS)
+CORRECT_OUTPUT_FOLDER = "./vdist"
+DUMMY_CONFIGURATION_FILE_ARGUMENTS = ["vdist", "batch", "config.cfg"]
+
+
+@contextlib.contextmanager
+def _create_dummy_configuration_file(configuration_text):
+    with tempfile.NamedTemporaryFile(mode="w") as temporary_file:
+        temporary_file.write(configuration_text)
+        yield temporary_file
+
+
+def test_configuration_file_read():
+    with _create_dummy_configuration_file(DUMMY_CONFIGURATION_TEXT) as config_file:
+        configurations = configuration.read(config_file)
+        assert configurations["Ubuntu-package"].builder_parameters == CORRECT_UBUNTU_PARAMETERS
+        assert configurations["Ubuntu-package"].output_folder == CORRECT_OUTPUT_FOLDER
+        assert "Centos7-package" in configurations
+
+
+def test_parse_arguments_configuration_file():
+    parsed_arguments = console_parser.parse_arguments(DUMMY_CONFIGURATION_FILE_ARGUMENTS)
+    assert parsed_arguments["configuration_file"] == "config.cfg"
+
+
+def test_move_package_to_output_folder():
+    with tempfile.NamedTemporaryFile(prefix=DUMMY_PACKAGE_NAME) as dummy_package:
+        builder._move_package_to_output_folder(DUMMY_CONFIGURATION)
+        assert os.path.isfile(os.path.join(DUMMY_OUTPUT_FOLDER,
+                                           dummy_package))
+
+
+def test_build_package():
+    with _create_dummy_configuration_file(DUMMY_CONFIGURATION_TEXT) as config_file:
+        configurations = configuration.read(config_file)
+        builder.build_package(configurations[0])
+        correct_output_package = os.path.join(configurations[0].output_folder,
+                                              ".".join(DUMMY_PACKAGE_NAME, "deb"))
+        assert os.path.isfile(correct_output_package)

--- a/tests/test_console_launcher.py
+++ b/tests/test_console_launcher.py
@@ -8,7 +8,7 @@ import vdist.builder as builder
 import vdist.console_parser as console_parser
 import vdist.configuration as configuration
 import vdist.source as source
-import vdist.vdist as vdist
+import vdist.vdist_launcher as vdist_launcher
 
 if sys.version_info[0] != 3:
     from testing_tools import TemporaryDirectory as OwnTemporaryDirectory
@@ -214,7 +214,7 @@ def test_build_package_batch():
 
 def test_build_package_manual():
     console_arguments = console_parser.parse_arguments(DUMMY_MANUAL_ARGUMENTS)
-    configurations = vdist._get_build_configurations(console_arguments)
+    configurations = vdist_launcher._get_build_configurations(console_arguments)
     _generate_packages(configurations)
 
 

--- a/tests/test_console_launcher.py
+++ b/tests/test_console_launcher.py
@@ -9,7 +9,7 @@ import vdist.builder as builder
 import vdist.console_parser as console_parser
 import vdist.configuration as configuration
 import vdist.source as source
-
+import vdist.vdist as vdist
 
 DUMMY_CONFIGURATION_TEXT = """[DEFAULT]
 app = geolocate
@@ -74,6 +74,27 @@ DUMMY_CONFIGURATION_ARGUMENTS["output_folder"] = DUMMY_OUTPUT_FOLDER
 DUMMY_CONFIGURATION = configuration.Configuration(DUMMY_CONFIGURATION_ARGUMENTS)
 CORRECT_OUTPUT_FOLDER = "./vdist"
 DUMMY_CONFIGURATION_FILE_ARGUMENTS = ["vdist", "batch", "config.cfg"]
+DUMMY_MANUAL_ARGUMENTS = ["vdist", "manual",
+                          "--app", "geolocate",
+                          "--version", "1.3.0",
+                          "--source", "https://github.com/dante-signal31/geolocate,master",
+                          "--profile", "ubuntu-trusty",
+                          "--compile_python",
+                          "--python_version", "3.4.4",
+                          "--fpm_args", '--maintainer dante.signal31@gmail.com -a native --url '
+                                        'https://github.com/dante-signal31/geolocate --description '
+                                        '"This program accepts any text and searchs inside every IP'
+                                        ' address. With each of those IP addresses, '
+                                        'geolocate queries '
+                                        'Maxmind GeoIP database to look for the city and '
+                                        'country where'
+                                        ' IP address or URL is located. Geolocate is designed to be'
+                                        ' used in console with pipes and redirections along with '
+                                        'applications like traceroute, nslookup, etc.'
+                                        ' " --license BSD-3 --category net',
+                          "--requirements_path", "/REQUIREMENTS.txt",
+                          "--runtime_deps", "libssl1.0.0, dummy1.0.0",
+                          "--output_folder", DUMMY_OUTPUT_FOLDER]
 
 
 @contextlib.contextmanager
@@ -103,10 +124,20 @@ def test_move_package_to_output_folder():
                                            dummy_package))
 
 
-def test_build_package():
+def test_build_package_batch():
     with _create_dummy_configuration_file(DUMMY_CONFIGURATION_TEXT) as config_file:
         configurations = configuration.read(config_file)
         builder.build_package(configurations[0])
         correct_output_package = os.path.join(configurations[0].output_folder,
                                               ".".join(DUMMY_PACKAGE_NAME, "deb"))
         assert os.path.isfile(correct_output_package)
+
+
+def test_build_package_manual():
+    console_arguments = console_parser.parse_arguments(DUMMY_MANUAL_ARGUMENTS)
+    configurations = vdist._get_build_configurations(console_arguments)
+    for _configuration in configurations:
+        builder.build_package(configurations[_configuration])
+    correct_output_package = os.path.join(configurations[0].output_folder,
+                                          ".".join(DUMMY_PACKAGE_NAME, "deb"))
+    assert os.path.isfile(correct_output_package)

--- a/tests/test_console_launcher.py
+++ b/tests/test_console_launcher.py
@@ -68,7 +68,8 @@ CORRECT_UBUNTU_PARAMETERS = {
     }
 
 DUMMY_PACKAGE_NAME = "geolocate-1.3.0-ubuntu-trusty"
-DUMMY_OUTPUT_FOLDER = "/tmp"
+DUMMY_PACKAGE_EXTENSION = ".deb"
+DUMMY_OUTPUT_FOLDER = "/tmp/vdist"
 DUMMY_CONFIGURATION_ARGUMENTS = CORRECT_UBUNTU_PARAMETERS
 DUMMY_CONFIGURATION_ARGUMENTS["output_folder"] = DUMMY_OUTPUT_FOLDER
 DUMMY_CONFIGURATION = configuration.Configuration(DUMMY_CONFIGURATION_ARGUMENTS)
@@ -118,10 +119,16 @@ def test_parse_arguments_configuration_file():
 
 
 def test_move_package_to_output_folder():
-    with tempfile.NamedTemporaryFile(prefix=DUMMY_PACKAGE_NAME) as dummy_package:
-        builder._move_package_to_output_folder(DUMMY_CONFIGURATION)
-        assert os.path.isfile(os.path.join(DUMMY_OUTPUT_FOLDER,
-                                           dummy_package))
+    with tempfile.TemporaryDirectory() as tempdir:
+        with tempfile.NamedTemporaryFile(prefix=DUMMY_PACKAGE_NAME,
+                                         suffix=DUMMY_PACKAGE_EXTENSION,
+                                         dir=tempdir) as dummy_package:
+            dummy_source_folder, dummy_package_name = os.path.split(dummy_package.name)
+            builder._move_package_to_output_folder(DUMMY_CONFIGURATION,
+                                                   source_folder=dummy_source_folder)
+            correct_package = os.path.join(DUMMY_OUTPUT_FOLDER,
+                                           dummy_package_name)
+            assert os.path.isfile(correct_package)
 
 
 def test_build_package_batch():

--- a/tests/testing_tools.py
+++ b/tests/testing_tools.py
@@ -1,0 +1,86 @@
+from __future__ import print_function
+
+import sys
+
+# Python 2.x specific tools.
+if sys.version_info[0] != 3:
+
+    # Python 2.x lacks of tempfile.TemporaryDirectory context manager
+    # so I must code my own context manager.
+    # Code adapted from:
+    #   http://stackoverflow.com/questions/19296146/tempfile-temporarydirectory-context-manager-in-python-2-7
+    import os
+    import warnings
+
+    from tempfile import mkdtemp
+
+    class TemporaryDirectory(object):
+        """Create and return a temporary directory.  This has the same
+        behavior as mkdtemp but can be used as a context manager.  For
+        example:
+
+            with TemporaryDirectory() as tmpdir:
+                ...
+
+        Upon exiting the context, the directory and everything contained
+        in it are removed.
+        """
+
+        def __init__(self, suffix="", prefix="tmp", dir=None):
+            self._closed = False
+            self.name = None  # Handle mkdtemp raising an exception
+            self.name = mkdtemp(suffix, prefix, dir)
+
+        def __repr__(self):
+            return "<{} {!r}>".format(self.__class__.__name__, self.name)
+
+        def __enter__(self):
+            return self.name
+
+        def __exit__(self, exc, value, tb):
+            self.cleanup()
+
+        def __del__(self):
+            # Issue a ResourceWarning if implicit cleanup needed
+            self.cleanup(_warn=True)
+
+        def _rmtree(self, path):
+            # Essentially a stripped down version of shutil.rmtree.  We can't
+            # use globals because they may be None'ed out at shutdown.
+            for name in os.listdir(path):
+                fullname = os.path.join(path, name)
+                try:
+                    isdir = os.path.isdir(fullname) and not os.path.islink(
+                        fullname)
+                except OSError:
+                    isdir = False
+                if isdir:
+                    self._rmtree(fullname)
+                else:
+                    try:
+                        os.remove(fullname)
+                    except OSError:
+                        pass
+            try:
+                os.rmdir(path)
+            except OSError:
+                pass
+
+        def cleanup(self, _warn=False):
+            if self.name and not self._closed:
+                try:
+                    self._rmtree(self.name)
+                except (TypeError, AttributeError) as ex:
+                    # Issue #10188: Emit a warning on stderr
+                    # if the directory could not be cleaned
+                    # up due to missing globals
+                    if "None" not in str(ex):
+                        raise
+                    print(
+                        "ERROR: {!r} while cleaning up {!r}".format(ex, self, ),
+                        file=sys.stderr)
+                    return
+                self._closed = True
+                if _warn:
+                    warnings.warn("Implicitly cleaning up {!r}".format(self),
+                                  ResourceWarning)

--- a/vdist/builder.py
+++ b/vdist/builder.py
@@ -24,7 +24,14 @@ def _create_package(_configuration):
 
 def _move_package_to_output_folder(_configuration,
                                    source_folder=defaults.BUILD_BASEDIR):
-    pass
+    if not os.path.exists(_configuration.output_folder):
+        os.makedirs(_configuration.output_folder, exist_ok=True)
+    for file in os.listdir(source_folder):
+        # Only copy files with extension as they are likely the generated
+        # package.
+        if os.path.splitext(file)[1] != "":
+            file_pathname = os.path.join(source_folder, file)
+            shutil.copy(file_pathname, _configuration.output_folder)
 
 
 class BuildProfile(object):

--- a/vdist/builder.py
+++ b/vdist/builder.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import logging
 import os
 import shutil
@@ -8,8 +10,8 @@ import threading
 import sys
 from jinja2 import Environment, FileSystemLoader
 
-import defaults
-import buildmachine
+import vdist.defaults as defaults
+import vdist.buildmachine as buildmachine
 
 
 def build_package(_configuration):

--- a/vdist/builder.py
+++ b/vdist/builder.py
@@ -7,8 +7,24 @@ import threading
 
 from jinja2 import Environment, FileSystemLoader
 
-from vdist import defaults
+import vdist.defaults as defaults
 from vdist.buildmachine import BuildMachine
+
+
+def build_package(_configuration):
+    _create_package(_configuration)
+    _move_package_to_output_folder(_configuration)
+
+
+def _create_package(_configuration):
+    builder = Builder()
+    builder.add_build(**_configuration.builder_parameters)
+    builder.build()
+
+
+def _move_package_to_output_folder(_configuration,
+                                   source_folder=defaults.BUILD_BASEDIR):
+    pass
 
 
 class BuildProfile(object):

--- a/vdist/buildmachine.py
+++ b/vdist/buildmachine.py
@@ -1,9 +1,12 @@
+from __future__ import absolute_import
+
 import itertools
 import logging
 import os
 import subprocess
 
-import defaults
+import vdist.defaults as defaults
+
 
 class BuildMachine(object):
 

--- a/vdist/buildmachine.py
+++ b/vdist/buildmachine.py
@@ -3,7 +3,7 @@ import logging
 import os
 import subprocess
 
-from vdist import defaults
+import vdist.defaults as defaults
 
 
 class BuildMachine(object):

--- a/vdist/buildmachine.py
+++ b/vdist/buildmachine.py
@@ -3,8 +3,7 @@ import logging
 import os
 import subprocess
 
-import vdist.defaults as defaults
-
+import defaults
 
 class BuildMachine(object):
 

--- a/vdist/configuration.py
+++ b/vdist/configuration.py
@@ -1,0 +1,20 @@
+import sys
+# The ConfigParser module has been renamed to configparser in Python 3
+if sys.version_info[0] == 3:
+    import configparser
+else:
+    import ConfigParser as configparser
+
+
+class Configuration(object):
+
+    def __init__(self, arguments):
+        self.output_folder = arguments.get("output_folder", None)
+        self.builder_parameters = {key: value for key, value in arguments.items()
+                                   if key != "output_folder"}
+        print(self.builder_parameters)
+
+
+def read(configuration_file):
+    pass
+

--- a/vdist/configuration.py
+++ b/vdist/configuration.py
@@ -15,6 +15,7 @@ LISTABLE_ARGUMENTS = {"source_git", "source_git_directory", "runtime_deps",
 LONG_TEXT_ARGUMENTS = {"fpm_args", "pip_args"}
 PROCESSABLE_ARGUMENTS = {"output_folder", "source_directory", "compile_python",
                          "fpm_args"}
+USELESS_ARGUMENTS = {"mode"}
 PROCESSABLE_ARGUMENTS |= LISTABLE_ARGUMENTS
 PROCESSABLE_ARGUMENTS |= LONG_TEXT_ARGUMENTS
 
@@ -24,7 +25,8 @@ class Configuration(object):
     def __init__(self, arguments):
         self.output_folder = arguments.get("output_folder", None)
         self.builder_parameters = {key: value for key, value in arguments.items()
-                                   if key not in PROCESSABLE_ARGUMENTS}
+                                   if key not in PROCESSABLE_ARGUMENTS and
+                                   key not in USELESS_ARGUMENTS}
         self._process_listable_arguments(arguments)
         self._process_long_text_arguments(arguments)
         self._process_source_directory_argument(arguments)

--- a/vdist/configuration.py
+++ b/vdist/configuration.py
@@ -5,18 +5,86 @@ if sys.version_info[0] == 3:
 else:
     import ConfigParser as configparser
 
+import vdist.source as source
+
+LISTABLE_ARGUMENTS = {"source_git", "source_git_directory", "runtime_deps",
+                      "build_deps"}
+LONG_TEXT_ARGUMENTS = {"fpm_args", "pip_args"}
+PROCESSABLE_ARGUMENTS = {"output_folder", "source_directory", "compile_python",
+                         "fpm_args"}
+PROCESSABLE_ARGUMENTS |= LISTABLE_ARGUMENTS
+PROCESSABLE_ARGUMENTS |= LONG_TEXT_ARGUMENTS
+
 
 class Configuration(object):
 
     def __init__(self, arguments):
         self.output_folder = arguments.get("output_folder", None)
         self.builder_parameters = {key: value for key, value in arguments.items()
-                                   if key != "output_folder"}
-        print(self.builder_parameters)
+                                   if key not in PROCESSABLE_ARGUMENTS}
+        self._process_listable_arguments(arguments)
+        self._process_long_text_arguments(arguments)
+        self._process_source_directory_argument(arguments)
+        self._process_compile_python_argument(arguments)
+
+    def _process_compile_python_argument(self, arguments):
+        if "compile_python" in arguments.keys():
+            self.builder_parameters["compile_python"] = bool(
+                arguments["compile_python"])
+
+    def _process_source_directory_argument(self, arguments):
+        if "source_directory" in arguments.keys():
+            directory = arguments["source_directory"]
+            directory = directory.strip()
+            self.builder_parameters["source"] = source.directory(directory)
+
+    def _process_long_text_arguments(self, arguments):
+        argument_keys = set(arguments.keys())
+        long_text_arguments_found = LONG_TEXT_ARGUMENTS.intersection(argument_keys)
+        for argument in long_text_arguments_found:
+            text_with_no_cr = _remove_cr(arguments[argument])
+            self.builder_parameters[argument] = text_with_no_cr
+
+    def _process_listable_arguments(self, arguments):
+        argument_keys = set(arguments.keys())
+        listable_arguments_found = LISTABLE_ARGUMENTS.intersection(argument_keys)
+        for argument in listable_arguments_found:
+            generated_list = _create_list(arguments[argument])
+            if argument == "source_git":
+                self.builder_parameters["source"] = source.git(
+                    generated_list[0],
+                    generated_list[1])
+            if argument == "source_git_directory":
+                self.builder_parameters["source"] = source.git_directory(
+                    generated_list[0],
+                    generated_list[1])
+            if argument in ["runtime_deps", "build_deps"]:
+                self.builder_parameters[argument] = generated_list
+
+
+def _create_list(text):
+    return [element.strip() for element in text.split(",")]
+
+
+def _remove_cr(text):
+    # Removes carriage returns from given text.
+    # Great reference:
+    #   http://stackoverflow.com/questions/3939361/remove-specific-characters-from-a-string-in-python
+    if sys.version_info[0] == 3:
+        return text.translate({ord('\n'): ord(' '), })
+    else:
+        return text.translate(' ', '\n')
+
 
 
 def read(configuration_file):
     # Should return a dict whose keys should be configfile sections
     # (except DEFAULT) and values a dict with parameter:value pairs.
-    pass
+    parser = configparser.ConfigParser(interpolation=configparser.ExtendedInterpolation())
+    parser.read(configuration_file)
+    configurations = {}
+    for section in parser.sections():
+        configurations[section] = {key: parser[section][key]
+                                   for key in parser[section]}
+    return configurations
 

--- a/vdist/configuration.py
+++ b/vdist/configuration.py
@@ -84,12 +84,13 @@ def _remove_cr(text):
 
 def read(configuration_file):
     # Should return a dict whose keys should be configfile sections
-    # (except DEFAULT) and values a dict with parameter:value pairs.
+    # (except DEFAULT) and configurations objects as values.
     parser = _get_config_parser()
     parser.read(configuration_file)
     configurations = {}
     for section in parser.sections():
-        configurations[section] = _get_section_values(parser, section)
+        parameters = _get_section_values(parser, section)
+        configurations[section] = Configuration(parameters)
     return configurations
 
 

--- a/vdist/configuration.py
+++ b/vdist/configuration.py
@@ -16,5 +16,7 @@ class Configuration(object):
 
 
 def read(configuration_file):
+    # Should return a dict whose keys should be configfile sections
+    # (except DEFAULT) and values a dict with parameter:value pairs.
     pass
 

--- a/vdist/configuration.py
+++ b/vdist/configuration.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import string
 import sys
 # The ConfigParser module has been renamed to configparser in Python 3
@@ -6,7 +8,7 @@ if sys.version_info[0] == 3:
 else:
     import ConfigParser as configparser
 
-import source
+import vdist.source as source
 
 LISTABLE_ARGUMENTS = {"source_git", "source_git_directory", "runtime_deps",
                       "build_deps"}

--- a/vdist/console_parser.py
+++ b/vdist/console_parser.py
@@ -1,0 +1,31 @@
+import argparse
+
+
+def parse_arguments(args=None):
+    arg_parser = argparse.ArgumentParser(description="A tool that lets you "
+                                                     "create OS packages from "
+                                                     "your Python applications "
+                                                     "in a clean and self "
+                                                     "contained manner.\n",
+                                         epilog="Follow vdist development at: "
+                                                "<https://github.com/objectified/vdist>")
+    subparsers = arg_parser.add_subparsers(help="Available modes")
+    automatic_subparser = subparsers.add_parser("batch",
+                                                help="Automatic configuration. "
+                                                     "Parameters are going to "
+                                                     " be read from a"
+                                                     "configuration file.")
+    automatic_subparser.add_argument("configuration_file",
+                                     nargs="?",
+                                     default=None,
+                                     type=argparse.FileType(),
+                                     metavar="CONFIGURATION FILENAME")
+    manual_subparser = subparsers.add_parser("manual",
+                                             help="Manual configuration. "
+                                                  "Parameters are going to be "
+                                                  "provided through flags.")
+    manual_subparser.add_argument("-a", "--app",
+                                  required=True,
+                                  help="Name of application to package.",
+                                  metavar="APPNAME")
+    return args(arg_parser.parse_args(args))

--- a/vdist/console_parser.py
+++ b/vdist/console_parser.py
@@ -18,7 +18,13 @@ def parse_arguments(args=None):
                                                      "contained manner.\n",
                                          epilog="Follow vdist development at: "
                                                 "<https://github.com/objectified/vdist>")
-    subparsers = arg_parser.add_subparsers(help="Available modes")
+    # There is a bug in Python 3.5 argparser that makes that missing arguments
+    # don't raise a "too few arguments". While that bug is finally fixed, there
+    # is a workaround in:
+    #   http://stackoverflow.com/questions/23349349/argparse-with-required-subparser
+    subparsers = arg_parser.add_subparsers(help="Available modes",
+                                           dest="mode")
+    subparsers.required = True
     automatic_subparser = subparsers.add_parser("batch",
                                                 help="Automatic configuration. "
                                                      "Parameters are going to "

--- a/vdist/console_parser.py
+++ b/vdist/console_parser.py
@@ -1,4 +1,13 @@
 import argparse
+import os.path
+
+
+def _check_is_file(_string):
+    if os.path.isfile(_string):
+        return _string
+    else:
+        raise argparse.ArgumentTypeError("{0} file does "
+                                         "not exists.".format(_string))
 
 
 def parse_arguments(args=None):
@@ -18,7 +27,7 @@ def parse_arguments(args=None):
     automatic_subparser.add_argument("configuration_file",
                                      nargs="?",
                                      default=None,
-                                     type=argparse.FileType(),
+                                     type=_check_is_file,
                                      metavar="CONFIGURATION FILENAME")
     manual_subparser = subparsers.add_parser("manual",
                                              help="Manual configuration. "
@@ -27,5 +36,102 @@ def parse_arguments(args=None):
     manual_subparser.add_argument("-a", "--app",
                                   required=True,
                                   help="Name of application to package.",
-                                  metavar="APPNAME")
-    return args(arg_parser.parse_args(args))
+                                  metavar="APP_NAME")
+    manual_subparser.add_argument("-v", "--version",
+                                  required=True,
+                                  help="Version of application to package.",
+                                  metavar="APP_VERSION")
+    source = manual_subparser.add_mutually_exclusive_group(required=True)
+    source.add_argument("-g", "--source_git",
+                        help="Location of remote git repository to build from.",
+                        metavar="APP_GIT")
+    source.add_argument("-G", "--source_git_directory",
+                        help="Location of local git repository to build from.",
+                        metavar="APP_GIT_DIRECTORY")
+    source.add_argument("-d", "--directory",
+                        help="Location of local directory to build from.",
+                        metavar="APP_DIRECTORY")
+    manual_subparser.add_argument("-p", "--profile",
+                                  required=True,
+                                  help="Build profile",
+                                  metavar="BUILD_PROFILE")
+    manual_subparser.add_argument("-n", "--name",
+                                  required=False,
+                                  help="Build name",
+                                  metavar="BUILD_NAME")
+    manual_subparser.add_argument("-b", "--build_deps",
+                                  required=False,
+                                  nargs="*",
+                                  help="Build dependencies.",
+                                  metavar="BUILD_DEPENDENCIES")
+    manual_subparser.add_argument("-r", "--runtime_deps",
+                                  required=False,
+                                  nargs="*",
+                                  help="Runtime dependencies.",
+                                  metavar="RUNTIME_DEPENDENCIES")
+    manual_subparser.add_argument("-c", "--custom_filename",
+                                  required=False,
+                                  help="Custom filename for generated package.",
+                                  metavar="CUSTOM_FILENAME")
+    manual_subparser.add_argument("-f", "--fpm_args",
+                                  required=False,
+                                  help="Extra arguments for FPM. (Put text "
+                                       "between quotes)",
+                                  metavar="FPM_ARGS")
+    manual_subparser.add_argument("-i", "--pip_args",
+                                  required=False,
+                                  help="Extra arguments for PIP. (Put text "
+                                       "between quotes)",
+                                  metavar="PIP_ARGS")
+    manual_subparser.add_argument("-B", "--python_basedir",
+                                  required=False,
+                                  help="Base directory were python "
+                                       "distribution "
+                                       "that is going to be packaged is placed "
+                                       "inside container. (Defaults to '/opt')",
+                                  metavar="PYTHON_BASEDIR")
+    manual_subparser.add_argument("-R", "--package_install_root",
+                                  required=False,
+                                  help="Base directory were this package "
+                                       "is going to be installed in target "
+                                       "system. (Defaults to 'python_basedir')",
+                                  metavar="INSTALL_ROOT")
+    manual_subparser.add_argument("-P", "--package_tmp_root",
+                                  required=False,
+                                  help="Temporal folder used in docker "
+                                       "container to build your package. "
+                                       "(Defaults to '/tmp')",
+                                  metavar="TMP_ROOT")
+    manual_subparser.add_argument("-D", "--working_dir",
+                                  required=False,
+                                  help="Subdirectory under your source tree "
+                                       "that is to be regarded as the base "
+                                       "directory",
+                                  metavar="WORKING_DIR")
+    manual_subparser.add_argument("-C", "--compile_python",
+                                  required=False,
+                                  help="Indicates Python should be fetched "
+                                       "from python.org, compiled and shipped "
+                                       "for you.",
+                                  action="store_const",
+                                  const="True",
+                                  default="False")
+    manual_subparser.add_argument("-V", "--python_version",
+                                  required=False,
+                                  help="Python version to package.",
+                                  metavar="PYTHON_VERSION")
+    manual_subparser.add_argument("-t", "--requirements_path",
+                                  required=False,
+                                  help="Path to your pip requirements file, "
+                                       "relative to your project root. "
+                                       "(Defaults to */requirements.txt*).",
+                                  metavar="REQUIREMENTS_PATH")
+    manual_subparser.add_argument("-o", "--output_folder",
+                                  required=False,
+                                  help="Folder where generated packages should "
+                                       "be placed.",
+                                  metavar="OUTPUT_FOLDER")
+    parsed_arguments = vars(arg_parser.parse_args(args))
+    filtered_parser_arguments = {key: value for key, value in parsed_arguments.items()
+                                 if value is not None}
+    return filtered_parser_arguments

--- a/vdist/profiles/centos6.sh
+++ b/vdist/profiles/centos6.sh
@@ -27,10 +27,11 @@ yum install -y {{build_deps|join(' ')}}
 # only install when needed, to save time with
 # pre-provisioned containers
 if [ ! -f /usr/bin/fpm ]; then
-    # Latest ruby 1.5.0 fails to install in centos 6.
-    # For more info read: https://github.com/jordansissel/fpm/issues/1090
-    # So force to 1.4.0 needed.
-    gem install fpm --version 1.4.0
+    # Latest fpm fails to install in Centos 6. There was a workaround
+    # for previous versions of fpm, but with last one it doesn't work
+    # any longer. Centos 6 profile won't work until this issue is fixed:
+    #   https://github.com/jordansissel/fpm/issues/1192
+    gem install fpm
 fi
 
 # install prerequisites

--- a/vdist/vdist.py
+++ b/vdist/vdist.py
@@ -1,0 +1,24 @@
+import sys
+
+import vdist.console_parser as console_parser
+import vdist.configuration as configuration
+import vdist.builder as builder
+
+
+def _get_build_configurations(arguments):
+    if arguments["configuration_file"] is None:
+        configurations = [configuration.Configuration(arguments), ]
+    else:
+        configurations = configuration.read(arguments["configuration_file"])
+    return configurations
+
+
+def main(args=sys.argv):
+    console_arguments = console_parser.parse_arguments(args)
+    configurations = _get_build_configurations(console_arguments)
+    for _configuration in configurations:
+        builder.build_package(_configuration)
+
+
+if __name__ == "__main__":
+    main()

--- a/vdist/vdist.py
+++ b/vdist/vdist.py
@@ -1,19 +1,23 @@
+#!/usr/bin/env python
 import sys
 
-import vdist.console_parser as console_parser
-import vdist.configuration as configuration
-import vdist.builder as builder
+import console_parser
+import configuration
+import builder
 
 
 def _get_build_configurations(arguments):
-    if arguments["configuration_file"] is None:
-        configurations = {"Default project": configuration.Configuration(arguments), }
-    else:
-        configurations = configuration.read(arguments["configuration_file"])
+    try:
+        if arguments["configuration_file"] is None:
+            configurations = {"Default project": arguments, }
+        else:
+            configurations = configuration.read(arguments["configuration_file"])
+    except KeyError:
+        configurations = {"Default project": arguments, }
     return configurations
 
 
-def main(args=sys.argv):
+def main(args=sys.argv[1:]):
     console_arguments = console_parser.parse_arguments(args)
     configurations = _get_build_configurations(console_arguments)
     for _configuration in configurations:

--- a/vdist/vdist.py
+++ b/vdist/vdist.py
@@ -7,7 +7,7 @@ import vdist.builder as builder
 
 def _get_build_configurations(arguments):
     if arguments["configuration_file"] is None:
-        configurations = {"default": configuration.Configuration(arguments), }
+        configurations = {"Default project": configuration.Configuration(arguments), }
     else:
         configurations = configuration.read(arguments["configuration_file"])
     return configurations

--- a/vdist/vdist.py
+++ b/vdist/vdist.py
@@ -7,7 +7,7 @@ import vdist.builder as builder
 
 def _get_build_configurations(arguments):
     if arguments["configuration_file"] is None:
-        configurations = [configuration.Configuration(arguments), ]
+        configurations = {"default": configuration.Configuration(arguments), }
     else:
         configurations = configuration.read(arguments["configuration_file"])
     return configurations
@@ -17,7 +17,7 @@ def main(args=sys.argv):
     console_arguments = console_parser.parse_arguments(args)
     configurations = _get_build_configurations(console_arguments)
     for _configuration in configurations:
-        builder.build_package(_configuration)
+        builder.build_package(configurations[_configuration])
 
 
 if __name__ == "__main__":

--- a/vdist/vdist.py
+++ b/vdist/vdist.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
+from __future__ import absolute_import
+
 import sys
 
-import console_parser
-import configuration
-import builder
+import vdist.console_parser as console_parser
+import vdist.configuration as configuration
+import vdist.builder as builder
 
 
 def _get_build_configurations(arguments):

--- a/vdist/vdist_launcher.py
+++ b/vdist/vdist_launcher.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
+
+# Be aware vdist_launcher is designed to be run as an "entry_point", i.e you
+# are not supossed to execute python vdist_launcher.py but just vdist command
+# after installing vdist package. If you try to run vdist_launcher.py directly
+# you are going to get ImportError unless you add vdist main folder (the
+# one with setup.py) to PYTHONPATH.
+
 from __future__ import absolute_import
 
 import sys

--- a/vdist/vdist_launcher.py
+++ b/vdist/vdist_launcher.py
@@ -18,11 +18,17 @@ import vdist.builder as builder
 def _get_build_configurations(arguments):
     try:
         if arguments["configuration_file"] is None:
-            configurations = {"Default project": arguments, }
+            configurations = _load_default_configuration(arguments)
         else:
             configurations = configuration.read(arguments["configuration_file"])
     except KeyError:
-        configurations = {"Default project": arguments, }
+        configurations = _load_default_configuration(arguments)
+    return configurations
+
+
+def _load_default_configuration(arguments):
+    _configuration = configuration.Configuration(arguments)
+    configurations = {"Default project": _configuration, }
     return configurations
 
 


### PR DESCRIPTION
Hi @objectified,

With this PR I propose a launcher to execute vdist from console. This way users have no longer to write a python script to make vdist work but just maintain a configuration file with parameters for all packages flavors they want to create.

Launcher is included in setup.py as an entry_point so an executable called vdist is created in Python's bin folder when vdist pypi package is installed. Be aware that vdist_launcher.py is not designed to be launched directly unless you add vdist base folder (the one with setup.py) to PYTHONPATH.

If this PR is accepted I will work on packaging vdist itself (to .deb and .rpm), so it can be installed and executed as a system wide tool.
